### PR TITLE
[cli] Init gocqlsh using gocql

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,49 +2,56 @@
 
 
 [[projects]]
+  digest = "1:b95738a1e6ace058b5b8544303c0871fc01d224ef0d672f778f696265d0f2917"
+  name = "github.com/chzyer/readline"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "62c6fe6193755f722b8b8788aa7357be55a50ff1"
+  version = "v1.4"
+
+[[projects]]
   branch = "master"
+  digest = "1:46bd2995dc829e29fffc157291c8ac16bf4bcac302fb745cafed6fb5c1f98d55"
   name = "github.com/gocql/gocql"
   packages = [
     ".",
     "internal/lru",
     "internal/murmur",
-    "internal/streams"
+    "internal/streams",
   ]
+  pruneopts = "UT"
   revision = "e06f8c1bcd787e6bf0608288b314522f08cc7848"
 
 [[projects]]
   branch = "master"
+  digest = "1:4a0c6bb4805508a6287675fac876be2ac1182539ca8a32468d8128882e9d5009"
   name = "github.com/golang/snappy"
   packages = ["."]
+  pruneopts = "UT"
   revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
 
 [[projects]]
   branch = "master"
+  digest = "1:364b908b9b27b97ab838f2f6f1b1f46281fa29b978a037d72a9b1d4f6d940190"
   name = "github.com/hailocab/go-hostpool"
   packages = ["."]
+  pruneopts = "UT"
   revision = "e80d13ce29ede4452c43dea11e79b9bc8a15b478"
 
 [[projects]]
-  name = "github.com/mattn/go-runewidth"
-  packages = ["."]
-  revision = "9e777a8366cce605130a531d2cd6363d07ad7317"
-  version = "v0.0.2"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/peterh/liner"
-  packages = ["."]
-  revision = "8c1271fcf47f341a9e6771872262870e1ad7650c"
-
-[[projects]]
+  digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
   name = "gopkg.in/inf.v0"
   packages = ["."]
+  pruneopts = "UT"
   revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
   version = "v0.9.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "2d0440ce9931b525709805fe38a6e8d8aa0f500d79a13420bbfb77d6f15197bc"
+  input-imports = [
+    "github.com/chzyer/readline",
+    "github.com/gocql/gocql",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -25,6 +25,18 @@
   revision = "e80d13ce29ede4452c43dea11e79b9bc8a15b478"
 
 [[projects]]
+  name = "github.com/mattn/go-runewidth"
+  packages = ["."]
+  revision = "9e777a8366cce605130a531d2cd6363d07ad7317"
+  version = "v0.0.2"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/peterh/liner"
+  packages = ["."]
+  revision = "8c1271fcf47f341a9e6771872262870e1ad7650c"
+
+[[projects]]
   name = "gopkg.in/inf.v0"
   packages = ["."]
   revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
@@ -33,6 +45,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "6a372eab26451b7383886b2dc1667755310a56fa48927ab91033fe00ece93501"
+  inputs-digest = "2d0440ce9931b525709805fe38a6e8d8aa0f500d79a13420bbfb77d6f15197bc"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,10 @@ shell-c3:
 	docker-compose exec c3 /bin/bash
 down:
 	docker-compose down
+
+fmt:
+	gofmt -d -l -w ./cmd ./pkg
+
+install:
+	go install ./cmd/gocqlsh
+	go install ./cmd/goyourcassandra

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,10 @@
+VERSION = 0.0.1
+BUILD_COMMIT = $(shell git rev-parse HEAD)
+BUILD_TIME = $(shell date +%Y-%m-%dT%H:%M:%S%z)
+CURRENT_USER = $(USER)
+FLAGS = -X main.version=$(VERSION) -X main.commit=$(BUILD_COMMIT) -X main.buildTime=$(BUILD_TIME) -X main.buildUser=$(CURRENT_USER)
+
+# --- cassandra ---
 .PHONY: run-c2 run-c3 shell-c2 shell-c3 down
 run-c2:
 	docker-compose up c2
@@ -9,10 +16,18 @@ shell-c3:
 	docker-compose exec c3 /bin/bash
 down:
 	docker-compose down
+# --- cassandra ---
 
+.PHONY: fmt install dep-update dep-install
 fmt:
 	gofmt -d -l -w ./cmd ./pkg
 
 install:
-	go install ./cmd/gocqlsh
-	go install ./cmd/goyourcassandra
+	go install -ldflags "$(FLAGS)" ./cmd/gocqlsh
+	go install -ldflags "$(FLAGS)" ./cmd/goyourcassandra
+
+dep-update:
+	dep ensure -v -update
+
+dep-install:
+	dep ensure

--- a/cmd/gocqlsh/main.go
+++ b/cmd/gocqlsh/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/gocql/gocql"
+	"github.com/peterh/liner"
+)
+
+func main() {
+	// TODO: print version etc.
+	fmt.Println("gocqlsh version 0.1")
+	cluster := gocql.NewCluster("localhost")
+	cluster.Keyspace = "system"
+	session, err := cluster.CreateSession()
+	if err != nil {
+		log.Fatal(err)
+		return
+	}
+	defer session.Close()
+	line := liner.NewLiner()
+	defer line.Close()
+	line.SetMultiLineMode(true)
+	line.SetCompleter(func(line string) []string {
+		if strings.HasSuffix(line, "a") {
+			return []string{"apple", "add", "ageis"}
+		}
+		return nil
+	})
+	// TODO: history
+	for {
+		select {
+		// TODO: handle signals, though I think liner is also handling ctrl d etc.
+		default:
+			// TODO: should have username in the prompt
+			l, err := line.Prompt("cqlsh> ")
+			if err != nil {
+				log.Fatal(err)
+				return
+			}
+			fmt.Printf("you typed %s\n", l)
+		}
+	}
+}

--- a/cmd/gocqlsh/main.go
+++ b/cmd/gocqlsh/main.go
@@ -2,45 +2,76 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"strings"
 
+	"github.com/chzyer/readline"
 	"github.com/gocql/gocql"
-	"github.com/peterh/liner"
 )
 
+var connectOnStart bool
+
+var _ readline.AutoCompleter = (*cqlshCompleter)(nil)
+
+type cqlshCompleter struct {
+}
+
+// Readline will pass the whole line and current offset to it
+// Completer need to pass all the candidates, and how long they shared the same characters in line
+// Example:
+//   [go, git, git-shell, grep]
+//   Do("g", 1) => ["o", "it", "it-shell", "rep"], 1
+//   Do("gi", 2) => ["t", "t-shell"], 2
+//   Do("git", 3) => ["", "-shell"], 3
+func (c *cqlshCompleter) Do(line []rune, pos int) (newLine [][]rune, length int) {
+	fmt.Println("line is", string(line))
+	return [][]rune{
+		{'o'},
+		{'i', 't'},
+	}, len(line)
+}
+
 func main() {
-	// TODO: print version etc.
-	fmt.Println("gocqlsh version 0.1")
-	cluster := gocql.NewCluster("localhost")
-	cluster.Keyspace = "system"
-	session, err := cluster.CreateSession()
+	fmt.Printf("gocqlsh version %s\n", version)
+	if connectOnStart {
+		cluster := gocql.NewCluster("localhost")
+		cluster.Keyspace = "system"
+		session, err := cluster.CreateSession()
+		if err != nil {
+			log.Fatal(err)
+			return
+		}
+		defer session.Close()
+	}
+
+	completer := cqlshCompleter{}
+	l, err := readline.NewEx(&readline.Config{
+		Prompt:       ">",
+		HistoryFile:  "/tmp/readline.tmp",
+		AutoComplete: &completer,
+	})
 	if err != nil {
 		log.Fatal(err)
 		return
 	}
-	defer session.Close()
-	line := liner.NewLiner()
-	defer line.Close()
-	line.SetMultiLineMode(true)
-	line.SetCompleter(func(line string) []string {
-		if strings.HasSuffix(line, "a") {
-			return []string{"apple", "add", "ageis"}
-		}
-		return nil
-	})
-	// TODO: history
 	for {
-		select {
-		// TODO: handle signals, though I think liner is also handling ctrl d etc.
-		default:
-			// TODO: should have username in the prompt
-			l, err := line.Prompt("cqlsh> ")
-			if err != nil {
-				log.Fatal(err)
-				return
+		line, err := l.Readline()
+		if err == readline.ErrInterrupt {
+			if len(line) == 0 {
+				break
+			} else {
+				continue
 			}
-			fmt.Printf("you typed %s\n", l)
+		} else if err == io.EOF {
+			break
+		}
+		line = strings.TrimSpace(line)
+		switch line {
+		case ":help":
+			fmt.Println("there is no help")
+		default:
+			fmt.Println("unknown", line)
 		}
 	}
 }

--- a/cmd/gocqlsh/version.go
+++ b/cmd/gocqlsh/version.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"io"
+)
+
+var (
+	version   string
+	commit    string
+	buildTime string
+	buildUser string
+)
+
+func printVersion(w io.Writer) {
+	fmt.Fprintf(w, "version: %s", version)
+	fmt.Fprintf(w, "git commit: %s", commit)
+	fmt.Fprintf(w, "build time: %s", buildTime)
+	fmt.Fprintf(w, "build user: %s", buildUser)
+}

--- a/pkg/gocql_test.go
+++ b/pkg/gocql_test.go
@@ -34,6 +34,15 @@ func TestListKeyspace(t *testing.T) {
 	}
 	iter := session.Query(descKeyspace).Iter()
 	fmt.Println(iter.Columns())
-	// TODO: it seems I need to use the iter.Scan to scan item out one by one ....
-	//row, err := iter.RowData()
+	for {
+		// New map each iteration
+		row := make(map[string]interface{})
+		if !iter.MapScan(row) {
+			break
+		}
+		// Do things with row
+		if ks, ok := row["keyspace_name"]; ok {
+			fmt.Printf("keyspace_name: %v\n", ks)
+		}
+	}
 }

--- a/pkg/gocql_test.go
+++ b/pkg/gocql_test.go
@@ -1,8 +1,8 @@
 package pkg
 
 import (
-	"testing"
 	"fmt"
+	"testing"
 
 	"github.com/gocql/gocql"
 )


### PR DESCRIPTION
It would be a while before I can finish my own cql driver (well, after playing xenoblade, the word driver looks weird without blade ...). And cli is much faster for early testing compared to Web UI.

Related 

- #3 find a cli library
  - https://github.com/peterh/liner is easy to get started, but the completion UI is too simple
  - https://github.com/chzyer/readline seems no longer maintained
- #2 find a table printer
  - need to think about JSON .... yeah, store json in cassandra for the win ....

TODO

- [x] cli with completion 
- [x] (optional) history
- [x] table output for query results
- [x] built in commands like `:version`, `!git status`